### PR TITLE
add :noquery so emacs doesn't ask about killing the process on exit

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -294,7 +294,8 @@ being prompted to kill the websocket server process."
    :service 4001
    :filter 'atomic-chrome-httpd-process-filter
    :filter-multibyte nil
-   :server t))
+   :server t
+   :noquery t))
 
 (defun atomic-chrome-normalize-header (header)
   "Destructively capitalize the components of HEADER."


### PR DESCRIPTION
Normally, when atomic-chrome's server is running and the user tries to exit Emacs, Emacs will say "Active processes exist; kill them and exit anyway?". This change will prevent Emacs from asking that. Most likely the user already understands that without Emacs running, they may not be able to use it to edit text.