### PR TITLE
Restore previous window layout

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -90,7 +90,7 @@ otherwise edit on Chrome is ignored while editing on Emacs."
 (defcustom atomic-chrome-url-major-mode-alist nil
   "Association list of URL regexp and corresponding major mode \
 which is used to select major mode for specified website."
-  :type '(alist :key-type (string :tag "regexp")
+  :type '(alist :key-type (regexp :tag "regexp")
                 :value-type (function :tag "major mode"))
   :group 'atomic-chrome)
 

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -206,7 +206,9 @@ TITLE is used for the buffer name and TEXT is inserted to the buffer."
       (save-restriction
         (run-hooks 'atomic-chrome-edit-done-hook)
         (when frame (delete-frame frame))
-        (kill-buffer buffer)))))
+        (if (eq atomic-chrome-buffer-open-style 'split)
+            (quit-window t)
+          (kill-buffer buffer))))))
 
 (defun atomic-chrome-close-current-buffer ()
   "Close current buffer and connection from client."


### PR DESCRIPTION
For example, I have buffer/window A displayed in a frame, and buffer/window B is
created (or occupied) by atomic-chrome.

Before:

A -> A|B -> A|A

After:

A -> A|B -> A

I make the new behavior only takes effect when the option
`atomic-chrome-buffer-open-style' is 'split (the default) because I have no
knowledage about the other possible options.