### PR TITLE
Stop using obsolete string-make-unibyte

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -228,7 +228,8 @@ TITLE is used for the buffer name and TEXT is inserted to the buffer."
 where FRAME show raw data received."
   (let ((msg (json-read-from-string
               (decode-coding-string
-               (string-make-unibyte (websocket-frame-payload frame)) 'utf-8))))
+               (encode-coding-string (websocket-frame-payload frame) 'utf-8)
+	       'utf-8))))
     (let-alist msg
       (if (eq (websocket-server-conn socket) atomic-chrome-server-ghost-text)
           (if (atomic-chrome-get-buffer-by-socket socket)


### PR DESCRIPTION
The byte-compiler warns that it is obsolete since 26.1.
Instead use encode-coding-string as recommended.