### PR TITLE
Add atomic-chrome-server-running-p

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -336,6 +336,21 @@ STRING is the string process received."
       (process-send-eof proc))))
 
 ;;;###autoload
+(defun atomic-chrome-server-running-p ()
+  "Returns `t' if the atomic-chrome server is currently running,
+`nil' otherwise."
+  (let ((retval nil))
+    (condition-case ex
+        (progn
+          (delete-process
+           (make-network-process
+            :name "atomic-client-test" :host "localhost"
+            :noquery t :service "64292"))
+          (setq retval t))
+      ('error nil))
+    retval))
+
+;;;###autoload
 (defun atomic-chrome-start-server ()
   "Start websocket server for atomic-chrome."
   (interactive)


### PR DESCRIPTION
This adds a method (autoloaded) that can check whether the atomic-chrome server
is running or not.

This will allow someone to do

```emacs-lisp
(when (not (atomic-chrome-server-running-p))
  (atomic-chrome-start-server))
```

Resolves #18