### PR TITLE
Explain that GhostText passes hostnames not URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The default major mode of editing buffer is `text-mode`. You can change the majo
 (setq atomic-chrome-default-major-mode 'markdown-mode)
 ```
 
-Additionally, you can use `atomic-chrome-url-major-mode-alist` to choose the major mode for a specific website based on the page URL like below.
+Additionally, you can use `atomic-chrome-url-major-mode-alist` to choose the major mode for a specific website based on the page URL (or, with GhostText, URL hostname) like below.
 
 ``` emacs-lisp
 (setq atomic-chrome-url-major-mode-alist

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -88,8 +88,9 @@ otherwise edit on Chrome is ignored while editing on Emacs."
   :group 'atomic-chrome)
 
 (defcustom atomic-chrome-url-major-mode-alist nil
-  "Association list of URL regexp and corresponding major mode \
-which is used to select major mode for specified website."
+  "Association list of URL (or, for GhostText, hostname) regexp \
+and corresponding major mode which is used to select major mode \
+for specified website."
   :type '(alist :key-type (regexp :tag "regexp")
                 :value-type (function :tag "major mode"))
   :group 'atomic-chrome)


### PR DESCRIPTION
See also discussion in https://github.com/GhostText/GhostText/issues/112.