### PR TITLE
Fix for an empty title in the `atomic-chrome-create-buffer`

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -194,7 +194,7 @@ or raising the selected frame depending on `atomic-chrome-buffer-open-style'."
   "Create buffer associated with websocket specified by SOCKET.
 URL is used to determine the major mode of the buffer created,
 TITLE is used for the buffer name and TEXT is inserted to the buffer."
-  (let ((buffer (generate-new-buffer title)))
+  (let ((buffer (generate-new-buffer (if (string-empty-p title) "No title" title))))
     (with-current-buffer buffer
       (puthash buffer
              (list socket (atomic-chrome-show-edit-buffer buffer title))


### PR DESCRIPTION
I have seen the following error: 
> Error (websocket): in callback `on-message': error: "Empty string for buffer name is not allowed"

It occurs on the page that do not have a title.
You can reproduce it as following steps:
1. Visit "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_textarea"
2. Open the console and reset a title as following: document.title = ""
3. Enable 'Ghost Text'
4. Click a textarea

the `title` in `atomic-chrome-create-buffer` is used as the buffer name.
the buffer name must not be an empty string.

In `atomic-chrome-create-buffer`:
```emacs-lisp
(generate-new-buffer title)
```
