### PR TITLE
Add variable atomic-chrome-server-ghost-text-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ By default, Atomic Chrome for Emacs accepts the connection request from both Ato
 (setq atomic-chrome-extension-type-list '(atomic-chrome))
 ```
 
+### Set Server Port for Ghost Text
+
+By default, Atomic Chrome for Emacs uses the default port 4001 for Ghost Text. If you need to set this to another port, you can do it by setting `atomic-chrome-server-ghost-text-port` like below.
+
+``` emacs-lisp
+(setq atomic-chrome-server-ghost-text-port 4002)
+```
+
+You may also need to update Ghost Text's port setting in Chrome Extensions page.
+
 ## History
 
 version 2.0.0 (2016-11-08)

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -113,6 +113,9 @@ for specified website."
 (defvar atomic-chrome-server-ghost-text nil
   "Websocket server connection handle for Ghost Text.")
 
+(defvar atomic-chrome-server-ghost-text-port 4001
+  "HTTP server port for Ghost Text.")
+
 (defvar atomic-chrome-buffer-table (make-hash-table :test 'equal)
   "Hash table of editing buffer and its assciated data.
 Each element has a list consisting of (websocket, frame).")
@@ -294,7 +297,7 @@ where FRAME show raw data received."
    :name "atomic-chrome-httpd"
    :family 'ipv4
    :host 'local
-   :service 4001
+   :service atomic-chrome-server-ghost-text-port
    :filter 'atomic-chrome-httpd-process-filter
    :filter-multibyte nil
    :server t

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -72,6 +72,11 @@
   :type 'integer
   :group 'atomic-chrome)
 
+(defcustom atomic-chrome-server-ghost-text-port 4001
+  "HTTP server port for Ghost Text."
+  :type 'integer
+  :group 'atomic-chrome)
+
 (defcustom atomic-chrome-enable-auto-update t
   "If non-nil, edit on Emacs is reflected to the browser instantly, \
 otherwise you need to type \"C-xC-s\" manually."
@@ -112,9 +117,6 @@ for specified website."
 
 (defvar atomic-chrome-server-ghost-text nil
   "Websocket server connection handle for Ghost Text.")
-
-(defvar atomic-chrome-server-ghost-text-port 4001
-  "HTTP server port for Ghost Text.")
 
 (defvar atomic-chrome-buffer-table (make-hash-table :test 'equal)
   "Hash table of editing buffer and its assciated data.


### PR DESCRIPTION
Fix #29

So that the port for GhostText can be configured by:

```elisp
(setq atomic-chrome-server-ghost-text-port 4002)
(atomic-chrome-start-server)
```

Let me know if any documentation updates are needed. :)