### PR TITLE
Fail silently if a server is already running

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -348,16 +348,20 @@ STRING is the string process received."
 
 ;;;###autoload
 (defun atomic-chrome-start-server ()
-  "Start websocket server for atomic-chrome."
+  "Start websocket server for atomic-chrome.  Fails silently if a \
+server is already running."
   (interactive)
-  (and (not atomic-chrome-server-atomic-chrome)
-       (memq 'atomic-chrome atomic-chrome-extension-type-list)
-       (setq atomic-chrome-server-atomic-chrome
-             (atomic-chrome-start-websocket-server 64292)))
-  (and (not (process-status "atomic-chrome-httpd"))
-       (memq 'ghost-text atomic-chrome-extension-type-list)
-       (atomic-chrome-start-httpd))
-  (global-atomic-chrome-edit-mode 1))
+  (condition-case nil
+      (progn
+        (and (not atomic-chrome-server-atomic-chrome)
+             (memq 'atomic-chrome atomic-chrome-extension-type-list)
+             (setq atomic-chrome-server-atomic-chrome
+                   (atomic-chrome-start-websocket-server 64292)))
+        (and (not (process-status "atomic-chrome-httpd"))
+             (memq 'ghost-text atomic-chrome-extension-type-list)
+             (atomic-chrome-start-httpd))
+        (global-atomic-chrome-edit-mode 1))
+    (error nil)))
 
 ;;;###autoload
 (defun atomic-chrome-stop-server nil

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -351,7 +351,7 @@ STRING is the string process received."
   "Start websocket server for atomic-chrome.  Fails silently if a \
 server is already running."
   (interactive)
-  (condition-case nil
+  (ignore-errors
       (progn
         (and (not atomic-chrome-server-atomic-chrome)
              (memq 'atomic-chrome atomic-chrome-extension-type-list)
@@ -360,8 +360,7 @@ server is already running."
         (and (not (process-status "atomic-chrome-httpd"))
              (memq 'ghost-text atomic-chrome-extension-type-list)
              (atomic-chrome-start-httpd))
-        (global-atomic-chrome-edit-mode 1))
-    (error nil)))
+        (global-atomic-chrome-edit-mode 1))))
 
 ;;;###autoload
 (defun atomic-chrome-stop-server nil


### PR DESCRIPTION
When running multiple Emacs instances, this method would have thrown an error and stopped evaluation of Emacs init files.

This solves the same issue as https://github.com/alpha22jp/atomic-chrome/pull/28, but it's slightly different:

- It is platform-independent
- It leaves an existing atomic chrome server running
  - Which makes sense, since many users have multiple Emacs instances
    running and they might be editing one text while opening a new instance