### PR TITLE
Require subr-x for string-empty-p

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -42,6 +42,7 @@
 (eval-when-compile (require 'cl))
 (require 'json)
 (require 'let-alist)
+(require 'subr-x)
 (require 'websocket)
 
 (defgroup atomic-chrome nil


### PR DESCRIPTION
Fixes #38 

To reproduce,

1. Execute emacs as follows.

   ```
   emacs -Q --eval "(progn (package-initialize) (package-refresh-contents) (package-install 'websocket))" -l atomic-chrome.el
   ```
2. Run <kbd>M-x</kbd> <kbd>atomic-chrome-start-server</kbd>
3. Click on GhostText button on browser.