### PR TITLE
Use cl-lib instead of cl

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ __Since v2.0.0, Atomic Chrome for Emacs supports [Ghost Text](https://github.com
 
 ## Requirements
 
-* Emacs: 24.3 or later
+* Emacs: 24.4 or later
 * OS: Tested on Windows and Linux
 
 ## Installation

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -39,7 +39,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 (require 'json)
 (require 'let-alist)
 (require 'subr-x)

--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2016 alpha22jp <alpha22jp@gmail.com>
 
 ;; Author: alpha22jp <alpha22jp@gmail.com>
-;; Package-Requires: ((emacs "24.3") (let-alist "1.0.4") (websocket "1.4"))
+;; Package-Requires: ((emacs "24.4") (let-alist "1.0.4") (websocket "1.4"))
 ;; Keywords: chrome edit textarea
 ;; URL: https://github.com/alpha22jp/atomic-chrome
 ;; Version: 2.0.0
@@ -42,7 +42,7 @@
 (eval-when-compile (require 'cl-lib))
 (require 'json)
 (require 'let-alist)
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 (require 'websocket)
 
 (defgroup atomic-chrome nil


### PR DESCRIPTION
Hi, I wrote minor fixes.

- cl library is now obsolete.
- subr-x library was introduced in Emacs 24.4.