### PR TITLE
add macOS to OS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ __Since v2.0.0, Atomic Chrome for Emacs supports [Ghost Text](https://github.com
 ## Requirements
 
 * Emacs: 24.4 or later
-* OS: Tested on Windows and Linux
+* OS: Tested on Windows and Linux, reported to work on macOS
 
 ## Installation
 


### PR DESCRIPTION
I use Atomic Chrome with GhostText on macOS successfully.
This adds that to the OS list, mentioning it is reported to work
rather than "tested" since I assume you don't personally do
that.