### PR TITLE
Fix frame opening in pgtk mode

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -186,7 +186,7 @@ frame, depending on `atomic-chrome-buffer-open-style'."
       (setq edit-frame
             (cond
              ((memq window-system '(pgtk x))
-              (if (string-match-p "wayland" x-display-name)
+              (if (or (not x-display-name) (string-match-p "wayland" x-display-name))
                   (make-frame frame-params)
                 (make-frame-on-display (getenv "DISPLAY") frame-params)))
              ;; Avoid using make-frame-on-display for Mac OS


### PR DESCRIPTION
When Emacs is running in pgtk mode the x-display-name can be nil even
though display is set up properly.

Without this change new frame would not open and error gets reported
instead (stringp expected on string-match-p and got nil instead).