### PR TITLE
docs: Update README to include chrome-emacs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is the Emacs version of [Atomic Chrome](https://github.com/tuvistavie/atomi
 
 __Since v2.0.0, Atomic Chrome for Emacs supports [Ghost Text](https://github.com/GhostText/GhostText) as browser extension, bringing compatibility with Firefox, too.__
 
+Since the [Atomic Chrome](https://github.com/tuvistavie/atomic-chrome) extension was removed from the Chrome Web Store, Atomic Chrome for Emacs now also supports [chrome-emacs](https://github.com/KarimAziev/chrome-emacs), a fork that adds support for Manifest V3.
+
 ## Screencast
 
 ![Screencast](https://github.com/alpha22jp/atomic-chrome/blob/master/images/screencast.gif)
@@ -20,7 +22,7 @@ __Since v2.0.0, Atomic Chrome for Emacs supports [Ghost Text](https://github.com
 
 ### For Chrome
 
-Install the [GhostText](https://chrome.google.com/webstore/detail/ghosttext/godiecgffnchndlihlpaajjcplehddca) Chrome extension.
+Install the [GhostText](https://chrome.google.com/webstore/detail/ghosttext/godiecgffnchndlihlpaajjcplehddca) or [chrome-emacs](https://chromewebstore.google.com/detail/chrome-emacs/dabdpcafiblbndpoadckibiaojbdnpjg) Chrome extension.
 
 ### For Firefox
 
@@ -98,7 +100,7 @@ If you select `frame`, you can also set the width and height of the frame with `
 
 ### Select available browser extension
 
-By default, Atomic Chrome for Emacs accepts the connection request from both Atomic Chrome and Ghost Text. If you never use one of them, you can disable it by setting `atomic-chrome-extension-type-list` like below.
+By default, Atomic Chrome for Emacs accepts connection requests from Atomic Chrome, Ghost Text, and chrome-emacs. If you prefer to use only specific extensions, you can customize the `atomic-chrome-extension-type-list` accordingly. For example, to accept connections only from Atomic Chrome or chrome-emacs (which requires the same settings as Atomic Chrome), you can set it like below.
 
 ``` emacs-lisp
 (setq atomic-chrome-extension-type-list '(atomic-chrome))


### PR DESCRIPTION
This pull request updates the README to reflect the current state of browser extension support in Atomic Chrome for Emacs. 

Given the removal of the Atomic Chrome extension from the Chrome Web Store, it's important for users to know about alternative ways to connect their browsers with Emacs. This update includes:

- Mentioning the support for the [chrome-emacs](https://github.com/KarimAziev/chrome-emacs) extension, a fork of Atomic Chrome that is compatible with Manifest V3.
- Updating the installation instructions for Chrome users to include the option to install either GhostText or chrome-emacs.
- Clarifying in the "Select available browser extension" section that Atomic Chrome for Emacs now also accepts connection requests from chrome-emacs, and providing an example configuration for users who wish to use specific extensions.

These changes ensure that users have the most up-to-date information on how to integrate their browser with Emacs using Atomic Chrome and its supported extensions.